### PR TITLE
Fix(Arq): pass job_id to JobDef in new version

### DIFF
--- a/arq_admin/compat.py
+++ b/arq_admin/compat.py
@@ -1,0 +1,4 @@
+from arq import VERSION as ARQ_VERSION
+
+
+ARQ_VERSION_TUPLE = tuple(int(x) for x in ARQ_VERSION.split("."))


### PR DESCRIPTION
After version 0.26.0, https://github.com/python-arq/arq/pull/378 has been added to JobDef which is job_id. We need to pass this new parameter since it breaks "All jobs" page